### PR TITLE
lock the object before modification

### DIFF
--- a/lib/rails_admin_toggleable/action.rb
+++ b/lib/rails_admin_toggleable/action.rb
@@ -30,7 +30,7 @@ module RailsAdmin
             end
             if params['id'].present?
               begin
-                @object = @abstract_model.model.unscoped.find(params['id'])
+                @object = @abstract_model.model.unscoped.lock.find(params['id'])
                 @meth = params[:method]
                 @object.send(@meth + '=', params[:on] == '1' ? true : false)
                 if @object.save


### PR DESCRIPTION
If a model has complicated after_save code there can be concurrency issues.  Pessimistically lock the model before changing it.

This is perhaps only a problem because the field doesn't block double-clicks.  Perhaps there should be another PR to disable a second click until the AJAX call returns. 
