### PR TITLE
Add compatibility for sub-directory deployed applications

### DIFF
--- a/lib/rails_admin_toggleable/field.rb
+++ b/lib/rails_admin_toggleable/field.rb
@@ -44,7 +44,7 @@ module RailsAdmin
             def g_link(fv, on, badge)
               bindings[:view].link_to(
                 fv.html_safe,
-                toggle_path(model_name: @abstract_model, id: bindings[:object].id, method: name, on: on.to_s),
+                bindings[:view].toggle_path(model_name: @abstract_model, id: bindings[:object].id, method: name, on: on.to_s),
                 # method: :post,
                 class: 'toggle-btn label ' + badge,
                 onclick: g_js


### PR DESCRIPTION
When setting config.relative_url_root, toggle_path may not respond with the correct relative_url_root prefix. Specifying the _path request to the view bindings, the responded string includes it.