### PR TITLE
make ajax optional

### DIFF
--- a/lib/rails_admin_toggleable/field.rb
+++ b/lib/rails_admin_toggleable/field.rb
@@ -53,6 +53,7 @@ module RailsAdmin
                 options[:onclick] = g_js
               else
                 options[:method] = :post
+                options[:onclick] = "$(this).html(\"<i class='fa fa-spinner fa-spin'></i>\");"
               end
 
               bindings[:view].link_to(

--- a/lib/rails_admin_toggleable/field.rb
+++ b/lib/rails_admin_toggleable/field.rb
@@ -18,6 +18,10 @@ module RailsAdmin
             :boolean
           end
 
+          register_instance_option :ajax do
+            true
+          end
+
           register_instance_option :pretty_value do
             def g_js
               <<-END.strip_heredoc.gsub("\n", ' ').gsub(/ +/, ' ')
@@ -41,13 +45,20 @@ module RailsAdmin
                 return false;
               END
             end
+
             def g_link(fv, on, badge)
+              options = { class: 'toggle-btn label ' + badge }
+
+              if self.ajax
+                options[:onclick] = g_js
+              else
+                options[:method] = :post
+              end
+
               bindings[:view].link_to(
                 fv.html_safe,
                 toggle_path(model_name: @abstract_model, id: bindings[:object].id, method: name, on: on.to_s),
-                # method: :post,
-                class: 'toggle-btn label ' + badge,
-                onclick: g_js
+                options
               )
             end
 


### PR DESCRIPTION
I like the UI of this custom field in the list view, but I have a "featured" flag, where only one item can be "featured" at a time. Setting featured to true for one item will un-set it on the previously featured item. My server logic performs correctly, and only one record will be set as 'featured' when toggled via this custom field, but the UI does not reflect that the previously featured item has now been un-featured. I see there is existing logic for preventing the async ui update on the clicked element and instead reloading the page from the server if `ajax` is false, but no way of setting that parameter. This should take care of that, adding it as an instance option. Default maintains existing behavior.

Published uses default behavior, Featured uses `ajax false` and logic which only allows one record to have the field set to true at any given time:

![toggle](https://cloud.githubusercontent.com/assets/3171662/24369568/b5103e36-1324-11e7-8ee7-e2328c02fc49.gif)
