### PR TITLE
On failure to update return UI back to previous state

### DIFF
--- a/lib/rails_admin_toggleable/field.rb
+++ b/lib/rails_admin_toggleable/field.rb
@@ -26,6 +26,7 @@ module RailsAdmin
             def g_js
               <<-END.strip_heredoc.gsub("\n", ' ').gsub(/ +/, ' ')
                 var $t = $(this);
+                var old_html = $t.html();
                 $t.html("<i class='fa fa-spinner fa-spin'></i>");
                 $.ajax({
                   type: "POST",
@@ -39,6 +40,7 @@ module RailsAdmin
                     $t.siblings(".toggle-btn").remove();
                   },
                   error: function(e) {
+                    $t.html(old_html);
                     alert(e.responseText);
                   }
                 });


### PR DESCRIPTION
If you click the toggle and saving the record fails it pops up an error message as expected.  However the toggle UI currently remains as a spinner icon.  This change returns the UI to the state that it was before the failure.